### PR TITLE
Use variable value for clipboard

### DIFF
--- a/src/components/tailwindColourNameResultBox.svelte
+++ b/src/components/tailwindColourNameResultBox.svelte
@@ -1,14 +1,14 @@
 <script>
     export let resultText;
 
-    const copyColourNameToClipboard = async (event) => {
+    const copyColourNameToClipboard = async () => {
         if (!navigator.clipboard) {
             // Clipboard API not available
             return;
         }
-        const text = event.target.innerText;
+        
         try {
-            await navigator.clipboard.writeText(text);
+            await navigator.clipboard.writeText(resultText);
         } catch (err) {
             console.error("Failed to copy!", err);
         }


### PR DESCRIPTION
Hello @edjw! When clicking the Tailwind input (to copy the class name), it will put the text "undefined" on your clipboard if you click on the clipboard SVG. It is because in the code it's bound to `event.target.innerText` (which the SVG doesn't have).

This PR fixes it by using the value of the variable `resultText` in stead of relying on the content of the clicked HTML.

Edit: thanks for this repo, it's a very handy tool 👍🏻 